### PR TITLE
mettre a jour la redirection de mon lien vers mon portail globalartpro

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -1,69 +1,10 @@
 <!DOCTYPE html>
 <html lang="fr">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>GlobalArtPro - Artistes du Monde</title>
-  <style>
-    body {
-      margin: 0;
-      font-family: Arial, sans-serif;
-      background: linear-gradient(to right, #141E30, #243B55);
-      color: white;
-      text-align: center;
-    }
-    header {
-      padding: 2rem;
-    }
-    header h1 {
-      font-size: 2.5rem;
-      margin: 0;
-    }
-    header p {
-      font-size: 1.2rem;
-      color: #ddd;
-    }
-    .buttons {
-      margin: 2rem 0;
-    }
-    .buttons a {
-      display: inline-block;
-      margin: 0.5rem;
-      padding: 1rem 2rem;
-      background: #ffcc00;
-      color: #000;
-      text-decoration: none;
-      border-radius: 8px;
-      font-weight: bold;
-      transition: 0.3s;
-    }
-    .buttons a:hover {
-      background: #ffaa00;
-    }
-    footer {
-      margin-top: 3rem;
-      padding: 1rem;
-      background: rgba(255, 255, 255, 0.1);
-      font-size: 0.9rem;
-    }
-  </style>
+  <meta http-equiv="refresh" content="0; url=https://noukawo81.github.io/Globalartpro/">
+  <title>Redirection vers GlobalArtPro</title>
 </head>
 <body>
-
-  <header>
-    <h1>🌍 GlobalArtPro</h1>
-    <p>La plateforme mondiale des artistes - Art, Culture & Innovation</p>
-  </header>
-
-  <section class="buttons">
-    <a href="https://rqtpnbwn.mychariow.store" target="_blank">🛒 Boutique Digitale (Shariow)</a>
-    <a href="https://globalartproadac3428.pinet.com" target="_blank">📱 Application Pi Network</a>
-    <a href="https://noukawo81.github.io/mini-studio-ia/" target="_blank">🎨 GAP Studio (IA + NFT)</a>
-  </section>
-
-  <footer>
-    © 2025 GlobalArtPro - Créé pour les artistes du monde entier
-  </footer>
-
+  <p>Redirection en cours vers le portail GlobalArtPro...</p>
 </body>
 </html>


### PR DESCRIPTION
Anciennement, le lien redirigeait vers un site multi-entreprises. Cette modification simplifie la navigation en pointant directement vers le portail GlobalArtPro.