### PR TITLE
ci(monitor): add dispatch trigger for manual debug runs

### DIFF
--- a/.github/workflows/ci-monitor.yml
+++ b/.github/workflows/ci-monitor.yml
@@ -3,6 +3,7 @@ name: CI Monitor - notify on failure
 on:
   workflow_run:
     types: [completed]
+  workflow_dispatch:
 
 permissions:
   issues: write


### PR DESCRIPTION
Allow manual dispatch of the CI monitor workflow so we can run it and inspect logs during debugging. This is temporary and only for investigation.